### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -15,8 +15,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config user.name "GitHub Actions"
-          git config user.email "github-actions@github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Fast-forward release branch
         run: |

--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -1,0 +1,27 @@
+# Fast-forward release branch to the latest release commit
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+name: Update release branch
+jobs:
+  fast-forward-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "github-actions@github.com"
+
+      - name: Fast-forward release branch
+        run: |
+          git fetch origin
+          git checkout release || git checkout -b release
+          git reset --hard ${{ github.event.release.tag_name || github.ref_name }}
+          git push origin release --force
+    

--- a/README.ja.md
+++ b/README.ja.md
@@ -59,7 +59,7 @@ Instant Replay は Unity で直近のゲームプレイ動画をいつでも保�
 [UnityNuGet の scoped registry を追加して](https://github.com/xoofx/UnityNuGet#add-scope-registry-manifestjson)、以下の git URL を Package Manager に追加してください。
 
 ```
-https://github.com/CyberAgentGameEntertainment/InstantReplay.git?path=/Packages/jp.co.cyberagent.instant-replay.dependencies
+https://github.com/CyberAgentGameEntertainment/InstantReplay.git?path=/Packages/jp.co.cyberagent.instant-replay.dependencies#release
 ```
 
 #### 方法2: 手動でのインストール
@@ -74,7 +74,7 @@ https://github.com/CyberAgentGameEntertainment/InstantReplay.git?path=/Packages/
 以下の git URL を Package Manager に追加してください。
 
 ```
-https://github.com/CyberAgentGameEntertainment/InstantReplay.git?path=Packages/jp.co.cyberagent.instant-replay
+https://github.com/CyberAgentGameEntertainment/InstantReplay.git?path=Packages/jp.co.cyberagent.instant-replay#release
 ```
 
 ## クイックスタート

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ There are two ways to install the dependencies. You can use either of them.
 [Add UnityNuGet scoped registry](https://github.com/xoofx/UnityNuGet#add-scope-registry-manifestjson) and add the following git URL to the package manager:
 
 ```
-https://github.com/CyberAgentGameEntertainment/InstantReplay.git?path=/Packages/jp.co.cyberagent.instant-replay.dependencies
+https://github.com/CyberAgentGameEntertainment/InstantReplay.git?path=/Packages/jp.co.cyberagent.instant-replay.dependencies#release
 ```
 
 #### Method 2: Install manually
@@ -76,7 +76,7 @@ Install individual packages using [NuGetForUnity](https://github.com/GlitchEnzo/
 Add the following git URL to the package manager:
 
 ```
-https://github.com/CyberAgentGameEntertainment/InstantReplay.git?path=Packages/jp.co.cyberagent.instant-replay
+https://github.com/CyberAgentGameEntertainment/InstantReplay.git?path=Packages/jp.co.cyberagent.instant-replay#release
 ```
 
 ## Quick Start


### PR DESCRIPTION
Currently README encourages user to install the package from `main`, which may have unreleased changes.  
We would like to use `release` branch to be installed, and this PR adds a workflow to update `release` branch to the latest released tag automatically.