### PR TITLE
Reduce by-frame heap allocations

### DIFF
--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/EventCallbackEntryPoint.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/EventCallbackEntryPoint.cs
@@ -10,6 +10,7 @@ namespace InstantReplay
 {
     internal class EventCallbackEntryPoint : MonoBehaviour
     {
+        private static WaitForEndOfFrame _waitForEndOfFrame;
         private bool _endOfFrameCoroutineRunning;
 
         #region Event Functions
@@ -29,7 +30,7 @@ namespace InstantReplay
             {
                 while (EndOfFrameInner != null)
                 {
-                    yield return new WaitForEndOfFrame();
+                    yield return _waitForEndOfFrame ??= new WaitForEndOfFrame();
                     try
                     {
                         EndOfFrameInner?.Invoke();

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Realtime/RealtimeTranscoder.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Realtime/RealtimeTranscoder.cs
@@ -55,7 +55,7 @@ namespace InstantReplay
         /// <summary>
         ///     Pushes a video frame for encoding.
         /// </summary>
-        public async ValueTask PushVideoFrameAsync(NativeArray<byte> frameData, uint width, uint height,
+        public ValueTask PushVideoFrameAsync(NativeArray<byte> frameData, uint width, uint height,
             double timestamp)
         {
             ThrowIfDisposed();
@@ -63,7 +63,7 @@ namespace InstantReplay
             if (frameData.Length == 0)
                 throw new ArgumentException("Frame data cannot be empty", nameof(frameData));
 
-            await _videoEncoder.PushFrameAsync(frameData, width, height, timestamp).ConfigureAwait(false);
+            return _videoEncoder.PushFrameAsync(frameData, width, height, timestamp);
         }
 
         /// <summary>


### PR DESCRIPTION
- Eliminated `WaitForEndOfFrame` allocations in the coroutine by caching it
- Eliminated by-frame state machine allocation caused by `async ValueTask`