### PR TITLE
CriAudioSampleProviderのSamplingRateフォールバック

### DIFF
--- a/Packages/jp.co.cyberagent.instant-replay/Cri/CriAudioSampleProvider.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Cri/CriAudioSampleProvider.cs
@@ -43,7 +43,15 @@ namespace InstantReplay.Cri
             {
                 var initializer = Object.FindObjectOfType<CriWareInitializer>();
                 if (initializer)
+                {
                     sampleRate = initializer.atomConfig.outputSamplingRate;
+                    // If the sampling rate is 0, CRI defaults to 48000.
+                    // See: https://game.criware.jp/manual/unity_plugin/latest/contents/cri4u_component_initializer.html
+                    if (sampleRate == 0)
+                    {
+                        sampleRate = 48000;
+                    }
+                }
                 else
                     try
                     {


### PR DESCRIPTION
`CRIinitializer.atomConfig.outputSamplingRate` が 0の時、OnProvideAudioSamplesに渡すTimeStampがNaNになってしまい、RealtimeRecorder.OnProvideAudioSamples内でのArrayPoolの確保領域数が負数になるパターンを発見しました。

CRI側ではSamplingRateが0の時は48kHzにフォールバックする実装が入っているようです。

cf. https://game.criware.jp/manual/unity_plugin/latest/contents/cri4u_component_initializer.html

今回の対応で、Atom ライブラリが出力する PCM データのサンプリングレートを取得することで、実際にCRI側で仕様されているSamplingRateをつかってTimeStampが計算されるようにしました。