### PR TITLE
Add null check on destroy UnityAudioSampleProviderReceiver

### DIFF
--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/UnityAudioSampleProvider.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/UnityAudioSampleProvider.cs
@@ -38,7 +38,13 @@ namespace InstantReplay
             _receiver.OnProvideAudioSamples -= OnListenerProvideAudioSamples;
             var receiver = _receiver;
             _receiver = null;
-            _synchronization.Post(_ => { Object.Destroy(receiver); }, null);
+            _synchronization.Post(_ =>
+            {
+                if (receiver)
+                {
+                    Object.Destroy(receiver);
+                }
+            }, null);
         }
 
         private static AudioListener SelectAudioListener()


### PR DESCRIPTION
- Adds null check on destroy `UnityAudioSampleProviderReceiver` to make it work when the component is already destroyed (e.g. exiting play mode)