### PR TITLE
Back-propagate whether `IPipelineInput<T>` will accept incoming value

### DIFF
--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/AsyncGPUReadbackTransform.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/AsyncGPUReadbackTransform.cs
@@ -6,8 +6,16 @@ namespace InstantReplay
 {
     internal class AsyncGPUReadbackTransform : IPipelineTransform<IFrameProvider.Frame, LazyVideoFrameData>
     {
-        public bool Transform(IFrameProvider.Frame input, out LazyVideoFrameData output)
+        public bool WillAcceptWhenNextWont => false;
+
+        public bool Transform(IFrameProvider.Frame input, out LazyVideoFrameData output, bool willAcceptedByNextInput)
         {
+            if (!willAcceptedByNextInput)
+            {
+                output = default;
+                return false;
+            }
+
             output = new LazyVideoFrameData(FrameReadback.ReadbackFrameAsync(input.Texture), input.Texture.width,
                 input.Texture.height, input.Timestamp);
             return true;

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/AsyncPipelineTransformInput.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/AsyncPipelineTransformInput.cs
@@ -21,7 +21,7 @@ namespace InstantReplay
 
         public ValueTask PushAsync(TIn value)
         {
-            if (!_pipelineTransform.Transform(value, out var output)) return default;
+            if (!_pipelineTransform.Transform(value, out var output, true)) return default;
             return _next.PushAsync(output);
         }
 

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/AudioSampleProviderSubscription.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/AudioSampleProviderSubscription.cs
@@ -22,6 +22,8 @@ namespace InstantReplay
             _next = next;
             provider.OnProvideAudioSamples += _delegate = (samples, channels, sampleRate, timestamp) =>
             {
+                if (!next.WillAccept()) return;
+
                 unsafe
                 {
                     fixed (float* samplesPtr = samples)

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/BoundedEncodedDataBufferAudioInput.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/BoundedEncodedDataBufferAudioInput.cs
@@ -17,6 +17,11 @@ namespace InstantReplay
             _buffer = buffer;
         }
 
+        public bool WillAccept()
+        {
+            return true;
+        }
+
         public void Push(EncodedFrame value)
         {
             if (!_buffer.TryAddAudioFrame(value))

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/BoundedEncodedDataBufferVideoInput.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/BoundedEncodedDataBufferVideoInput.cs
@@ -17,6 +17,11 @@ namespace InstantReplay
             _buffer = buffer;
         }
 
+        public bool WillAccept()
+        {
+            return true;
+        }
+
         public void Push(EncodedFrame value)
         {
             if (!_buffer.TryAddVideoFrame(value))

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/FramePreprocessorInput.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/FramePreprocessorInput.cs
@@ -15,8 +15,16 @@ namespace InstantReplay
             _outputDataStartsAtTop = outputDataStartsAtTop;
         }
 
-        public bool Transform(IFrameProvider.Frame input, out IFrameProvider.Frame output)
+        public bool WillAcceptWhenNextWont => false;
+
+        public bool Transform(IFrameProvider.Frame input, out IFrameProvider.Frame output, bool willAcceptedByNextInput)
         {
+            if (!willAcceptedByNextInput)
+            {
+                output = default;
+                return false;
+            }
+
             var outTex = _preprocessor.Process(input.Texture, input.DataStartsAtTop ^ _outputDataStartsAtTop);
             output = new IFrameProvider.Frame(outTex, input.Timestamp, _outputDataStartsAtTop);
             return true;

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/FrameProviderSubscription.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/FrameProviderSubscription.cs
@@ -21,7 +21,11 @@ namespace InstantReplay
             _provider = provider;
             _disposeProvider = disposeProvider;
             _next = next;
-            provider.OnFrameProvided += _delegate = frame => next.Push(frame);
+            provider.OnFrameProvided += _delegate = frame =>
+            {
+                if (!next.WillAccept()) return;
+                next.Push(frame);
+            };
         }
 
         public void Dispose()

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/IPipelineInput.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/IPipelineInput.cs
@@ -15,6 +15,12 @@ namespace InstantReplay
     internal interface IPipelineInput<in T> : IDisposable
     {
         /// <summary>
+        ///     Whether the input will accept a new value now.
+        /// </summary>
+        /// <returns></returns>
+        bool WillAccept();
+
+        /// <summary>
         ///     Pushes a value to the input. This should be completed immediately.
         /// </summary>
         /// <param name="value"></param>

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/IPipelineTransform.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/IPipelineTransform.cs
@@ -8,6 +8,21 @@ namespace InstantReplay
 {
     internal interface IPipelineTransform<in TIn, TOut> : IDisposable
     {
-        bool Transform(TIn input, out TOut output);
+        /// <summary>
+        ///     Indicates whether to accept the input when the next pipeline input is not accepting.
+        /// </summary>
+        bool WillAcceptWhenNextWont { get; }
+
+        /// <summary>
+        ///     Transforms an input to an output.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="output"></param>
+        /// <param name="willAcceptedByNextInput">
+        ///     Whether the next pipeline input will accept an element to be produced by this
+        ///     transform from now.
+        /// </param>
+        /// <returns></returns>
+        bool Transform(TIn input, out TOut output, bool willAcceptedByNextInput);
     }
 }

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/PipelineTransformInput.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/PipelineTransformInput.cs
@@ -18,9 +18,14 @@ namespace InstantReplay
             _next = next;
         }
 
+        public bool WillAccept()
+        {
+            return _pipelineTransform.WillAcceptWhenNextWont || _next.WillAccept();
+        }
+
         public void Push(TIn value)
         {
-            if (!_pipelineTransform.Transform(value, out var output)) return;
+            if (!_pipelineTransform.Transform(value, out var output, _next.WillAccept())) return;
 
             _next.Push(output);
         }

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/VideoTemporalAdjuster.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/VideoTemporalAdjuster.cs
@@ -23,8 +23,16 @@ namespace InstantReplay
             _fixedFrameInterval = fixedFrameInterval;
         }
 
-        public bool Transform(T input, out T output)
+        public bool WillAcceptWhenNextWont => false;
+
+        public bool Transform(T input, out T output, bool willAcceptedByNextInput)
         {
+            if (!willAcceptedByNextInput)
+            {
+                output = default;
+                return false;
+            }
+
             var realTime = _recordingTimeProvider.Now;
 
             output = default;


### PR DESCRIPTION
- Currently `AsyncGPUReadback` will run and rent temporary buffer from `ArrayPool<byte>` even if the input queue is full. In this case, `AsyncGPUReadback` is awaited and the buffer will be returned immediately after the readback completes, but this may increase peak of memory usage.
- This PR changes `IPipelineInput<T>` to back-propagate whether it will accept incoming value at that time to prior pipeline elements, enabling `AsyncGPUReadback` to avoid allocate buffers if unnecessary.