### PR TITLE
fix libunienc is not imported for Apple Silicon macOS players

### DIFF
--- a/Packages/jp.co.cyberagent.instant-replay/UniEnc/Plugins/aarch64-apple-darwin/libunienc.dylib.meta
+++ b/Packages/jp.co.cyberagent.instant-replay/UniEnc/Plugins/aarch64-apple-darwin/libunienc.dylib.meta
@@ -55,7 +55,7 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        CPU: None
+        CPU: ARM64
   - first:
       Standalone: Win
     second:


### PR DESCRIPTION
Closes #77 