### PR TITLE
Fix errors when URP is absent

### DIFF
--- a/Packages/jp.co.cyberagent.instant-replay/UniversalRP/InstantReplay.UniversalRP.asmdef
+++ b/Packages/jp.co.cyberagent.instant-replay/UniversalRP/InstantReplay.UniversalRP.asmdef
@@ -12,12 +12,19 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "INSTANTREPLAY_URP"
+    ],
     "versionDefines": [
         {
             "name": "com.unity.render-pipelines.universal",
             "expression": "17.0",
             "define": "INSTANTREPLAY_URP_17_0_OR_NEWER"
+        },
+        {
+            "name": "com.unity.render-pipelines.universal",
+            "expression": "",
+            "define": "INSTANTREPLAY_URP"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
Reported by #106 

Fixes compilation errors when URP is not installed to the project. `InstantReplay.UniversalRP`, which is depends on URP installation, has not been excluded from the compilation when URP is absent.