### PR TITLE
Avoid AppController conflict in iOS build

### DIFF
--- a/Packages/jp.co.cyberagent.instant-replay/UniEnc/Plugins/iOS/RegisterPlugin.mm
+++ b/Packages/jp.co.cyberagent.instant-replay/UniEnc/Plugins/iOS/RegisterPlugin.mm
@@ -1,19 +1,24 @@
 #import "UnityAppController.h"
+#import "PluginBase/LifeCycleListener.h"
 #include "Unity/IUnityGraphics.h"
 
 extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API unienc_UnityPluginLoad(IUnityInterfaces* unityInterfaces);
 extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API unienc_UnityPluginUnload();
 
-@interface MyAppController : UnityAppController
-{
-}
-- (void)shouldAttachRenderDelegate;
+@interface UniEncLifeCycleListener : NSObject<LifeCycleListener>
 @end
-@implementation MyAppController
-- (void)shouldAttachRenderDelegate
-{
-    UnityRegisterRenderingPluginV5(&unienc_UnityPluginLoad, &unienc_UnityPluginUnload);
+
+@implementation UniEncLifeCycleListener
+
++ (void)load {
+    static UniEncLifeCycleListener* listener = nil;
+    listener = [[self alloc] init];
+    UnityRegisterLifeCycleListener(listener);
+}
+
+- (void)didFinishLaunching:(NSNotification*)notification {
+    UnityRegisterRenderingPluginV5(&unienc_UnityPluginLoad,
+                                   &unienc_UnityPluginUnload);
 }
 
 @end
-IMPL_APP_CONTROLLER_SUBCLASS(MyAppController);


### PR DESCRIPTION
Since unienc is integrated as a static library on iOS, the UnityPluginLoad function is not called automatically and must be called manually. In InstantReplay, we previously used `IMPL_APP_CONTROLLER_SUBCLASS` following the [official sample](https://github.com/Unity-Technologies/NativeRenderingPlugin/blob/master/UnityProject/Assets/Plugins/iOS/RegisterPlugin.mm), but this definition is not suitable for a library because it causes a compilation error if it overlaps within the project.

Instead, I have changed it to use LifeCycleListener to hook into the app launch event and call UnityPluginLoad.