### PR TITLE
Exclude InstantReplay.UniversalRP with the define symbol

### DIFF
--- a/Packages/jp.co.cyberagent.instant-replay/UniversalRP/InstantReplay.UniversalRP.asmdef
+++ b/Packages/jp.co.cyberagent.instant-replay/UniversalRP/InstantReplay.UniversalRP.asmdef
@@ -13,7 +13,8 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [
-        "INSTANTREPLAY_URP"
+        "INSTANTREPLAY_URP",
+        "!EXCLUDE_INSTANTREPLAY"
     ],
     "versionDefines": [
         {


### PR DESCRIPTION
Fixed the InstantReplay.UniversalRP assembly not being excluded by EXCLUDE_INSTANTREPLAY.