### PR TITLE
Use features to generate third party notices

### DIFF
--- a/.github/workflows/build-unienc.yml
+++ b/.github/workflows/build-unienc.yml
@@ -188,7 +188,7 @@ jobs:
           submodules: 'recursive'
       - run: |
           cargo install cargo-about --locked
-          cargo about generate about.hbs > ../../THIRD-PARTY-NOTICES.md
+          cargo about generate --features unity,mimalloc about.hbs > ../../THIRD-PARTY-NOTICES.md
         working-directory: InstantReplay.Externals/unienc
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-unienc.yml
+++ b/.github/workflows/build-unienc.yml
@@ -187,7 +187,7 @@ jobs:
         with:
           submodules: 'recursive'
       - run: |
-          cargo install cargo-about --locked
+          cargo install cargo-about --locked --features cli
           cargo about generate --features unity,mimalloc about.hbs > ../../THIRD-PARTY-NOTICES.md
         working-directory: InstantReplay.Externals/unienc
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Adjust the Rust compilation features to include mimalloc in the automatic generation of THIRD-PARTY-NOTICES.md.