### PR TITLE
Update unity_native_plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "InstantReplay.Externals/unienc/external/unity-native-plugin-rs"]
-	path = InstantReplay.Externals/unienc/external/unity-native-plugin-rs
-	url = https://github.com/ruccho/unity-native-plugin-rs.git
 [submodule "InstantReplay.Externals/unienc/external/muxide"]
 	path = InstantReplay.Externals/unienc/external/muxide
 	url = https://github.com/ruccho/muxide

--- a/InstantReplay.Externals/unienc/Cargo.lock
+++ b/InstantReplay.Externals/unienc/Cargo.lock
@@ -1220,7 +1220,6 @@ dependencies = [
  "tokio",
  "unienc_common",
  "unity-native-plugin",
- "unity-native-plugin-vulkan",
 ]
 
 [[package]]
@@ -1312,8 +1311,11 @@ dependencies = [
 
 [[package]]
 name = "unity-native-plugin"
-version = "0.8.0"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b87595f1063af99a3bd106e3ab6d99c38ccf68d9ead7ef61f7f2388d07a357e"
 dependencies = [
+ "ash",
  "objc2",
  "objc2-foundation",
  "objc2-metal",
@@ -1322,16 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "unity-native-plugin-sys"
-version = "0.8.0"
-
-[[package]]
-name = "unity-native-plugin-vulkan"
-version = "0.8.0"
-dependencies = [
- "ash",
- "unity-native-plugin",
- "unity-native-plugin-sys",
-]
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "179c8a544cb30336ccb9e65fe1b88dc916efbf1c85698548ab5f4d61e4e5be2e"
 
 [[package]]
 name = "unty"

--- a/InstantReplay.Externals/unienc/Cargo.toml
+++ b/InstantReplay.Externals/unienc/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [ "./crates/*", "./external/unity-native-plugin-rs/Cargo.toml", "./external/muxide/Cargo.toml" ]
+members = [ "./crates/*", "./external/muxide/Cargo.toml" ]
 default-members = ["./crates/unienc_c"]
 resolver = "2"
 
@@ -15,12 +15,9 @@ unienc_windows_mf = { path = "./crates/unienc_windows_mf" }
 unienc_apple_vt = { path = "./crates/unienc_apple_vt" }
 unienc_ffmpeg = {  path = "./crates/unienc_ffmpeg" }
 unienc_webcodecs = {  path = "./crates/unienc_webcodecs" }
-unity-native-plugin = { path = "./external/unity-native-plugin-rs/unity-native-plugin" }
-unity-native-plugin-vulkan = { path = "./external/unity-native-plugin-rs/unity-native-plugin-vulkan" }
+unity-native-plugin = "0.9.0"
 
 [patch.crates-io]
-unity-native-plugin = { path = "./external/unity-native-plugin-rs/unity-native-plugin" }
-unity-native-plugin-vulkan = { path = "./external/unity-native-plugin-rs/unity-native-plugin-vulkan" }
 muxide = { path = "./external/muxide" }
 mimalloc = { path = "./external/mimalloc_rust"}
 

--- a/InstantReplay.Externals/unienc/crates/unienc_android_mc/Cargo.toml
+++ b/InstantReplay.Externals/unienc/crates/unienc_android_mc/Cargo.toml
@@ -15,5 +15,4 @@ ndk-sys = { version = "0.6.0", features = ["media"] }
 bitflags = "2.9.1"
 libc = "0.2.174"
 ash = "0.38.0"
-unity-native-plugin = { workspace = true, features = ["profiler"] }
-unity-native-plugin-vulkan.workspace = true
+unity-native-plugin = { workspace = true, features = ["profiler", "vulkan"] }

--- a/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/vulkan/mod.rs
+++ b/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/vulkan/mod.rs
@@ -16,15 +16,9 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 use crate::error::{AndroidError, Result, ResultExt};
-use unity_native_plugin::graphics::{GfxDeviceEventType, UnityGraphics};
-use unity_native_plugin::profiler::{
-    BuiltinProfilerCategory, ProfilerCategoryId, ProfilerMarkerDesc, ProfilerMarkerEventType,
-    ProfilerMarkerFlag, ProfilerMarkerFlags, UnityProfiler,
-};
-use unity_native_plugin_vulkan::vulkan::{
-    UnityGraphicsVulkanV2, VulkanEventRenderPassPreCondition, VulkanGraphicsQueueAccess,
-    VulkanPluginEventConfig,
-};
+use unity_native_plugin::graphics::{GfxDeviceEventType, IUnityGraphics, UnityGraphics};
+use unity_native_plugin::profiler::{BuiltinProfilerCategory, IUnityProfiler, ProfilerCategoryId, ProfilerMarkerDesc, ProfilerMarkerEventType, ProfilerMarkerFlag, ProfilerMarkerFlags, UnityProfiler};
+use unity_native_plugin::vulkan::{IUnityGraphicsVulkan, UnityGraphicsVulkanV2, VulkanEventRenderPassPreCondition, VulkanGraphicsQueueAccess, VulkanPluginEventConfig};
 
 use crate::vulkan::preprocess::PreprocessRenderPass;
 use crate::vulkan::utils::FencePool;

--- a/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/vulkan/preprocess/mod.rs
+++ b/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/vulkan/preprocess/mod.rs
@@ -12,6 +12,7 @@ use crate::vulkan::{GlobalContext, ProfilerMarkerDescExt, MARKERS};
 use ash::vk;
 use std::future::Future;
 use std::sync::{Arc, Mutex};
+use unity_native_plugin::vulkan::IUnityGraphicsVulkan;
 
 const VERT: &[u8] = include_bytes!("preprocess.vert.glsl.spv");
 const FRAG: &[u8] = include_bytes!("preprocess.frag.glsl.spv");

--- a/InstantReplay.Externals/unienc/crates/unienc_apple_vt/Cargo.toml
+++ b/InstantReplay.Externals/unienc/crates/unienc_apple_vt/Cargo.toml
@@ -25,7 +25,7 @@ objc2-metal = "0.3.2"
 objc2-video-toolbox = "0.3.1"
 tokio = { version = "1.45.1", features = ["sync"] }
 unienc_common = { workspace = true, features = ["unity"] }
-unity-native-plugin = { workspace = true, features = ["metal_objc2"] }
+unity-native-plugin = { workspace = true, features = ["metal"] }
 
 [features]
 default = []

--- a/InstantReplay.Externals/unienc/crates/unienc_apple_vt/src/metal/mod.rs
+++ b/InstantReplay.Externals/unienc/crates/unienc_apple_vt/src/metal/mod.rs
@@ -23,9 +23,9 @@ use objc2_metal::{
 use tokio::sync::oneshot;
 use unity_native_plugin::{
     graphics::{GfxDeviceEventType, UnityGraphics},
-    metal::objc2::{UnityGraphicsMetalV1Interface, UnityGraphicsMetalV2, UnityGraphicsMetalV2Interface},
+    metal::{UnityGraphicsMetalV1Interface, UnityGraphicsMetalV2, UnityGraphicsMetalV2Interface},
 };
-
+use unity_native_plugin::graphics::IUnityGraphics;
 use crate::error::{AppleError, Result, OsStatusExt};
 
 use crate::common::UnsafeSendRetained;


### PR DESCRIPTION
With the release of the official unity_native_plugin_rs 0.9.0, there is no longer a need to use the fork. I will remove the fork's submodule and update it to use the official release.