### PR TITLE
Implement disposed guards and safe reset checks for resources

### DIFF
--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/AudioTemporalAdjuster.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/AudioTemporalAdjuster.cs
@@ -145,6 +145,7 @@ namespace InstantReplay
 
         public void Dispose()
         {
+            _disposed = true;
         }
     }
 }

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/VideoEncoderInput.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/VideoEncoderInput.cs
@@ -14,6 +14,7 @@ namespace InstantReplay
         private readonly IAsyncPipelineInput<EncodedFrame> _next;
         private readonly Task _transferTask;
         private readonly VideoEncoder _videoEncoder;
+        private bool _disposed;
 
         internal VideoEncoderInput(VideoEncoder videoEncoder, IAsyncPipelineInput<EncodedFrame> next)
         {
@@ -35,6 +36,8 @@ namespace InstantReplay
 
         public void Dispose()
         {
+            if (_disposed) return;
+            _disposed = true;
             _videoEncoder?.Dispose();
             _next?.Dispose();
         }
@@ -116,7 +119,7 @@ namespace InstantReplay
                         encodedFrame.Dispose();
                         throw;
                     }
-                } while (true);
+                } while (!_disposed);
             }
             finally
             {

--- a/Packages/jp.co.cyberagent.instant-replay/UniEnc/Runtime/SharedBufferPool.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/UniEnc/Runtime/SharedBufferPool.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using AOT;
 using UniEnc.Native;
@@ -187,6 +188,7 @@ namespace UniEnc
 
             protected override void Reset()
             {
+                if (EqualityComparer<T>.Default.Equals(_value, default)) return;
                 _value.Dispose();
                 _value = default;
             }


### PR DESCRIPTION
## Summary
This PR adds defensive checks to prevent `ObjectDisposedException` and invalid handle access errors that could occur during resource cleanup, particularly during shutdown or rapid start/stop cycles.

## Changes
- **VideoEncoderInput**: 
  - Introduced a `_disposed` flag with proper guard in `Dispose()`.
  - Stop the background transfer loop cleanly when disposed, allowing the task to shut down gracefully without accessing disposed objects.

- **AudioTemporalAdjuster**:
  - Set the disposed flag explicitly in `Dispose()` for consistent state management.

- **SharedBufferPool / PooledHandle**:
  - Added a safety check in `Reset()` using `EqualityComparer<T>.Default` to skip disposal when the value is `default(T)`. This prevents attempts to dispose already-released or uninitialized handles (e.g., NativeArrayWrapper).

## Motivation
These changes address the following exceptions observed in the field:

<details>
<summary>ObjectDisposedException: Cannot access a disposed object.</summary>

```
ObjectDisposedException: Cannot access a disposed object.
Object name: '_outputHandle'.
UniEnc.VideoEncoder.PullFrameAsync () (at UnityProject/Packages/InstantReplay/Packages/jp.co.cyberagent.instant-replay/UniEnc/Runtime/VideoEncoder.cs:140)
InstantReplay.VideoEncoderInput.TransferAsync (InstantReplay.IAsyncPipelineInput`1[T] next) (at UnityProject/Packages/InstantReplay/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/VideoEncoderInput.cs:104)
InstantReplay.VideoEncoderInput.TransferAsync (InstantReplay.IAsyncPipelineInput`1[T] next) (at UnityProject/Packages/InstantReplay/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/VideoEncoderInput.cs:124)
InstantReplay.ValueTaskUtils+WhenAnySource+<>c.<Rent>b__6_1 (System.ValueTuple`3[T1,T2,T3] ctx) (at UnityProject/Packages/InstantReplay/Packages/jp.co.cyberagent.instant-replay/Runtime/ValueTaskUtils.cs:85)
UnityEngine.Debug:LogException(Exception)
InstantReplay.DefaultLogger:LogException(Exception) (at UnityProject/Packages/InstantReplay/Packages/jp.co.cyberagent.instant-replay/Runtime/ILogger.cs:39)
InstantReplay.ILogger:LogExceptionCore(Exception) (at UnityProject/Packages/InstantReplay/Packages/jp.co.cyberagent.instant-replay/Runtime/ILogger.cs:71)
InstantReplay.<>c:<Rent>b__6_1(ValueTuple`3) (at UnityProject/Packages/InstantReplay/Packages/jp.co.cyberagent.instant-replay/Runtime/ValueTaskUtils.cs:94)
InstantReplay.Core:<.ctor>b__3_0() (at UnityProject/Packages/InstantReplay/Packages/jp.co.cyberagent.instant-replay/Runtime/PooledAction.cs:64)
UnityEngine.UnitySynchronizationContext:ExecuteTasks()
```

</details>

<details>
<summary>The Handle has already been released.</summary>

```
The Handle has already been released.
UnityEngine.StackTraceUtility:ExtractStackTrace ()
Unity.Collections.LowLevel.Unsafe.AtomicSafetyHandle:Release (Unity.Collections.LowLevel.Unsafe.AtomicSafetyHandle)
UniEnc.Unity.NativeArrayWrapper:System.IDisposable.Dispose () (at UnityProject/Packages/InstantReplay/Packages/jp.co.cyberagent.instant-replay/UniEnc.Unity/Runtime/NativeArrayWrapper.cs:27)
UniEnc.SharedBuffer`1/Handle<UniEnc.Unity.NativeArrayWrapper>:Reset () (at UnityProject/Packages/InstantReplay/Packages/jp.co.cyberagent.instant-replay/UniEnc/Runtime/SharedBufferPool.cs:190)
UniEnc.PooledHandle:ReleaseHandle () (at UnityProject/Packages/InstantReplay/Packages/jp.co.cyberagent.instant-replay/UniEnc/Runtime/Internal/PooledHandle.cs:31)
System.Runtime.InteropServices.SafeHandle:Finalize ()
```

</details>