### PR TITLE
Add EXCLUDE_INSTANTREPLAY define to URP asmdef

### DIFF
--- a/Packages/jp.co.cyberagent.instant-replay/UniversalRP/InstantReplay.UniversalRP.asmdef
+++ b/Packages/jp.co.cyberagent.instant-replay/UniversalRP/InstantReplay.UniversalRP.asmdef
@@ -13,7 +13,8 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [
-        "INSTANTREPLAY_URP"
+        "INSTANTREPLAY_URP",
+        "!EXCLUDE_INSTANTREPLAY"
     ],
     "versionDefines": [
         {


### PR DESCRIPTION
## Summary
Added the conditional define constraint `!EXCLUDE_INSTANTREPLAY` to `InstantReplay.UniversalRP.asmdef`.

## Changes
- Updated `InstantReplay.UniversalRP.asmdef`
  - Added `"!EXCLUDE_INSTANTREPLAY"` to `defineConstraints`

This provides a clean way to conditionally compile out InstantReplay's URP-specific code.