### PR TITLE
fix: Obsolete warnings on Unity 2023.2 or newer

### DIFF
--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Legacy/FrameReadbackRequest.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Legacy/FrameReadbackRequest.cs
@@ -14,6 +14,12 @@ using UnityEngine.Experimental.Rendering;
 using UnityEngine.Profiling;
 using UnityEngine.Rendering;
 
+#if UNITY_2023_2_OR_NEWER
+using GraphicsFormatUsage = UnityEngine.Experimental.Rendering.GraphicsFormatUsage;
+#else
+using GraphicsFormatUsage = UnityEngine.Experimental.Rendering.FormatUsage;
+#endif
+
 namespace InstantReplay
 {
     internal readonly struct FrameReadbackRequest<TContext>
@@ -48,7 +54,7 @@ namespace InstantReplay
 
             try
             {
-                if (!SystemInfo.IsFormatSupported(_format, FormatUsage.ReadPixels))
+                if (!SystemInfo.IsFormatSupported(_format, GraphicsFormatUsage.ReadPixels))
                     throw new ArgumentException($"GraphicsFormat {_format} not supported for readback");
 
                 var size = GraphicsFormatUtility.ComputeMipmapSize(source.width, source.height, source.graphicsFormat);

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/FrameReadback.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/FrameReadback.cs
@@ -12,6 +12,12 @@ using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
 
+#if UNITY_2023_2_OR_NEWER
+using GraphicsFormatUsage = UnityEngine.Experimental.Rendering.GraphicsFormatUsage;
+#else
+using GraphicsFormatUsage = UnityEngine.Experimental.Rendering.FormatUsage;
+#endif
+
 namespace InstantReplay
 {
     /// <summary>
@@ -32,7 +38,7 @@ namespace InstantReplay
                 throw new ArgumentNullException(nameof(texture));
 
             // Check if format is supported
-            if (!SystemInfo.IsFormatSupported(texture.graphicsFormat, FormatUsage.ReadPixels))
+            if (!SystemInfo.IsFormatSupported(texture.graphicsFormat, GraphicsFormatUsage.ReadPixels))
                 throw new ArgumentException(
                     $"GraphicsFormat {texture.graphicsFormat} not supported for readback");
 


### PR DESCRIPTION
This PR fixes the following obsolete warnings.
```log
CS0618: Method 'UnityEngine.SystemInfo.IsFormatSupported(GraphicsFormat, FormatUsage)' is obsolete: 'Use overload with a GraphicsFormatUsage parameter instead'
CS0618: Enum 'UnityEngine.Experimental.Rendering.FormatUsage' is obsolete: 'Use GraphicsFormatUsage instead'
```

GraphicsFormatUsage is an API introduced in 2023.2, and FormatUsage is obsolete.
