### PR TITLE
unienc_comon: Clippy fix

### DIFF
--- a/InstantReplay.Externals/unienc/crates/unienc_common/src/buffer.rs
+++ b/InstantReplay.Externals/unienc/crates/unienc_common/src/buffer.rs
@@ -56,6 +56,10 @@ impl SharedBuffer {
         *self.len
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn data(&self) -> &[u8] {
         &self.data
     }


### PR DESCRIPTION
Fixes the following warnings when running clippy for unienc_common.

`cargo clippy -p unienc_common --all-targets -- -D warnings`
```bash
error: struct `SharedBuffer` has a public `len` method, but no `is_empty` method
  --> crates/unienc_common/src/buffer.rs:55:5
   |
55 |     pub fn len(&self) -> usize {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#len_without_is_empty
   = note: `-D clippy::len-without-is-empty` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::len_without_is_empty)]`

error: could not compile `unienc_common` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

---

I plan to submit another PR for additional Clippy fixes.