### PR TITLE
Fix compilation errors with Unity 6.4 (URP 17.4) or newer

### DIFF
--- a/Packages/jp.co.cyberagent.instant-replay/UniversalRP/InstantReplay.UniversalRP.asmdef
+++ b/Packages/jp.co.cyberagent.instant-replay/UniversalRP/InstantReplay.UniversalRP.asmdef
@@ -26,6 +26,11 @@
             "name": "com.unity.render-pipelines.universal",
             "expression": "",
             "define": "INSTANTREPLAY_URP"
+        },
+        {
+            "name": "com.unity.render-pipelines.universal",
+            "expression": "17.4",
+            "define": "INSTANTREPLAY_URP_17_4_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/Packages/jp.co.cyberagent.instant-replay/UniversalRP/InstantReplayFrameRenderPass.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/UniversalRP/InstantReplayFrameRenderPass.cs
@@ -47,6 +47,7 @@ namespace InstantReplay.UniversalRP
         }
 #endif
 
+#if !INSTANTREPLAY_URP_17_4_OR_NEWER
 #if INSTANTREPLAY_URP_17_0_OR_NEWER
         [Obsolete]
 #endif
@@ -60,5 +61,6 @@ namespace InstantReplay.UniversalRP
                     SystemInfo.graphicsUVStartsAtTop ^ flipped, commandBuffer));
             context.ExecuteCommandBuffer(commandBuffer);
         }
+#endif
     }
 }


### PR DESCRIPTION
In Unity 6.4 (URP 17.4), the RenderGraph Compatibility Mode was completely removed, and I fixed the compilation errors that occurred as a result.