### PR TITLE
unienc: deduplicate s16le audio sample conversion

### DIFF
--- a/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/audio/mod.rs
+++ b/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/audio/mod.rs
@@ -109,9 +109,9 @@ impl EncoderInput for MediaCodecAudioEncoderInput {
 }
 
 async fn push_impl(this: &mut MediaCodecAudioEncoderInput, data: AudioSample) -> Result<()> {
-    // Convert i16 samples to byte array
-    let byte_data_vec = i16_to_bytes(&data.data);
-    let mut byte_data = byte_data_vec.as_slice();
+    // Convert i16 samples to signed 16-bit little-endian PCM bytes.
+    let byte_data = data.data_as_s16le_bytes();
+    let mut byte_data = byte_data.as_slice();
 
     while !byte_data.is_empty() {
         // Get input buffer
@@ -200,13 +200,4 @@ fn create_audio_format<A: unienc_common::AudioEncoderOptions>(
     )?;
 
     SafeGlobalRef::new(env, format_obj)
-}
-
-// Convert i16 samples to byte array (little-endian)
-fn i16_to_bytes(samples: &[i16]) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(samples.len() * 2);
-    for &sample in samples {
-        bytes.extend_from_slice(&sample.to_le_bytes());
-    }
-    bytes
 }

--- a/InstantReplay.Externals/unienc/crates/unienc_common/src/lib.rs
+++ b/InstantReplay.Externals/unienc/crates/unienc_common/src/lib.rs
@@ -1,6 +1,7 @@
 use std::ffi::c_void;
 use std::fmt::Debug;
 use std::future::Future;
+use std::mem::size_of;
 use std::path::Path;
 
 use crate::buffer::SharedBuffer;
@@ -181,6 +182,17 @@ pub struct AudioSample {
     pub timestamp_in_samples: u64,
 }
 
+impl AudioSample {
+    /// Returns the sample data as signed 16-bit little-endian PCM bytes.
+    pub fn data_as_s16le_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(self.data.len() * size_of::<i16>());
+        for &sample in &self.data {
+            bytes.extend_from_slice(&sample.to_le_bytes());
+        }
+        bytes
+    }
+}
+
 pub trait EncodedData: Encode + Decode<()> {
     fn timestamp(&self) -> f64;
     fn set_timestamp(&mut self, timestamp: f64);
@@ -212,4 +224,22 @@ pub trait GraphicsEventIssuer: Send + 'static {
 pub trait EncoderOutput: Send {
     type Data: EncodedData + Send;
     fn pull(&mut self) -> impl Future<Output = Result<Option<Self::Data>>> + Send;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audio_sample_data_as_s16le_bytes_uses_little_endian_order() {
+        let sample = AudioSample {
+            data: vec![0x1234, -2, i16::MIN],
+            timestamp_in_samples: 0,
+        };
+
+        assert_eq!(
+            sample.data_as_s16le_bytes(),
+            vec![0x34, 0x12, 0xfe, 0xff, 0x00, 0x80]
+        );
+    }
 }

--- a/InstantReplay.Externals/unienc/crates/unienc_ffmpeg/src/audio/mod.rs
+++ b/InstantReplay.Externals/unienc/crates/unienc_ffmpeg/src/audio/mod.rs
@@ -88,15 +88,10 @@ impl EncoderInput for FFmpegAudioEncoderInput {
     type Data = AudioSample;
 
     async fn push(&mut self, data: Self::Data) -> unienc_common::Result<()> {
-        let data = unsafe {
-            std::slice::from_raw_parts::<u8>(
-                data.data.as_ptr() as *const u8,
-                data.data.len() * std::mem::size_of::<i16>(),
-            )
-        };
+        let data = data.data_as_s16le_bytes();
 
         self.input
-            .write_all(data)
+            .write_all(data.as_ref())
             .await
             .map_err(FFmpegError::from)?;
         self.input.flush().await.map_err(FFmpegError::from)?;

--- a/InstantReplay.Externals/unienc/crates/unienc_webcodecs/src/audio/mod.rs
+++ b/InstantReplay.Externals/unienc/crates/unienc_webcodecs/src/audio/mod.rs
@@ -89,10 +89,11 @@ impl<R: Runtime + 'static> EncoderInput for WebCodecsAudioEncoderInput<R> {
         }
 
         let encoder_handle = self.encoder_handle.as_ref().unwrap();
+        let audio_data = data.data_as_s16le_bytes();
 
         encoder_handle
             .push_audio_frame(
-                unsafe { data.data.align_to::<u8>() }.1,
+                audio_data.as_ref(),
                 self.channels,
                 self.sample_rate,
                 data.timestamp_in_samples as f64 / self.sample_rate as f64,


### PR DESCRIPTION
- Move i16-to-s16le PCM byte conversion onto `AudioSample`
- Replace Android, FFmpeg, and WebCodecs local byte conversion logic with the shared method

##### Verifications
see my repository for the test details : https://github.com/paq/InstantReplay/actions/runs/27399720904/job/80974742069