### PR TITLE
Reference Wwise assembly by name

### DIFF
--- a/Packages/jp.co.cyberagent.instant-replay/Wwise/InstantReplay.Wwise.asmdef
+++ b/Packages/jp.co.cyberagent.instant-replay/Wwise/InstantReplay.Wwise.asmdef
@@ -2,8 +2,8 @@
     "name": "InstantReplay.Wwise",
     "rootNamespace": "",
     "references": [
-        "GUID:1050604f2d3a84fcabcc4e9b9ff6745b",
-        "GUID:ecd9f69847c334f18aeaa435fde6d2f7"
+        "InstantReplay",
+        "AK.Wwise.Unity.API"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
- It seems that the GUIDs assigned to Wwise Assembly Definitions are not stable and may vary between projects. I have changed the references to use names instead of GUIDs.