### PR TITLE
Carry integer sample position through audio pipeline to avoid rounding gaps

### DIFF
--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/AudioEncoderInput.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/AudioEncoderInput.cs
@@ -12,15 +12,12 @@ namespace InstantReplay
     {
         private readonly AudioEncoder _audioEncoder;
         private readonly IAsyncPipelineInput<EncodedFrame> _next;
-        private readonly double _sampleRateInOptions;
         private readonly SharedTaskRaceGuard _raceGuard;
         private readonly Task _transferTask;
 
-        internal AudioEncoderInput(AudioEncoder audioEncoder, double sampleRateInOptions,
-            IAsyncPipelineInput<EncodedFrame> next)
+        internal AudioEncoderInput(AudioEncoder audioEncoder, IAsyncPipelineInput<EncodedFrame> next)
         {
             _audioEncoder = audioEncoder ?? throw new ArgumentNullException(nameof(audioEncoder));
-            _sampleRateInOptions = sampleRateInOptions;
             _next = next;
             _transferTask = TransferAsync(next);
             _raceGuard = new SharedTaskRaceGuard(_transferTask);
@@ -50,10 +47,14 @@ namespace InstantReplay
             if (value.Data.IsEmpty)
                 throw new ArgumentException("Audio data cannot be empty", nameof(value.Data));
 
-            // Push samples to audio encoder
+            // Push samples to audio encoder.
+            // Use the integer sample position carried on the frame instead of reconstructing it from the
+            // seconds-based Timestamp; `(ulong)(Timestamp * sampleRate)` truncates and intermittently lands
+            // one sample early, which the native encoder treats as a one-sample forward gap and fills with
+            // silence (audible clicks and audio drift).
             try
             {
-                await _audioEncoder.PushSamplesAsync(value.Data, (ulong)(value.Timestamp * _sampleRateInOptions))
+                await _audioEncoder.PushSamplesAsync(value.Data, (ulong)value.SamplePosition)
                     .ConfigureAwait(false);
             }
             catch (ObjectDisposedException)

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/AudioTemporalAdjuster.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/AudioTemporalAdjuster.cs
@@ -148,10 +148,13 @@ namespace InstantReplay
             // blank/skip mechanism, so this keeps the emitted timestamp exactly consistent with the sample
             // count and avoids handing the encoder a spurious timestamp discontinuity (which it would then
             // compensate for again, on top of the blank, causing audio to lag video on resume).
+            // `currentSamplePosition` is also carried as-is (integer) so the encoder input does not have to
+            // recover it from the seconds-based timestamp, which would truncate and produce spurious
+            // one-sample gaps on the native side.
             var outputTimestamp = currentSamplePosition / _sampleRateInOption;
 
             output = new PcmAudioFrame(writeBufferArray, writeBufferArray.AsMemory(0, writeLength),
-                outputTimestamp);
+                outputTimestamp, currentSamplePosition);
 
             return true;
         }

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/PcmAudioFrame.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/Pipeline/PcmAudioFrame.cs
@@ -16,11 +16,20 @@ namespace InstantReplay
         public readonly ReadOnlyMemory<short> Data;
         public readonly double Timestamp;
 
-        public PcmAudioFrame(short[] rendArray, ReadOnlyMemory<short> data, double timestamp)
+        /// <summary>
+        ///     The exact sample position (in the output sample rate) where this frame's data begins.
+        ///     Carried as an integer so the encoder receives contiguous positions without the rounding
+        ///     error a seconds-based (double) round trip would introduce, which the native side would
+        ///     otherwise detect as a spurious gap and fill with silence.
+        /// </summary>
+        public readonly long SamplePosition;
+
+        public PcmAudioFrame(short[] rendArray, ReadOnlyMemory<short> data, double timestamp, long samplePosition)
         {
             _array = rendArray;
             Data = data;
             Timestamp = timestamp;
+            SamplePosition = samplePosition;
         }
 
         public void Dispose()

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/RealtimeInstantReplaySession.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/RealtimeInstantReplaySession.cs
@@ -137,7 +137,7 @@ namespace InstantReplay
                     options.AudioOptions.Channels,
                     options.AudioLagAdjustmentThreshold).AsInput(
                     new PcmAudioFrameDroppingChannelInput(audioInputQueueSizeSamples,
-                        new AudioEncoderInput(audioEncoder, options.AudioOptions.SampleRate,
+                        new AudioEncoderInput(audioEncoder,
                             new BoundedEncodedDataBufferAudioInput(buffer).AsAsync()))));
 
             _temporalController.Resume();

--- a/Packages/jp.co.cyberagent.instant-replay/Runtime/UnboundedRecordingSession.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/Runtime/UnboundedRecordingSession.cs
@@ -133,7 +133,7 @@ namespace InstantReplay
                     options.AudioOptions.Channels,
                     options.AudioLagAdjustmentThreshold).AsInput(
                     new PcmAudioFrameDroppingChannelInput(audioInputQueueSizeSamples,
-                        new AudioEncoderInput(audioEncoder, options.AudioOptions.SampleRate,
+                        new AudioEncoderInput(audioEncoder,
                             new MuxerAudioInput(muxer)))));
 
             _temporalController.Resume();


### PR DESCRIPTION
## Summary

The audio sample position was truncated through a round-trip `double` conversion, causing the Rust side to detect a spurious 1-sample gap and insert silence.

- `AudioTemporalAdjuster` converts the `long` sample position to seconds (`double`) via `/_sampleRateInOption` and stores it in `PcmAudioFrame.Timestamp`.
- `AudioEncoderInput` converts it back to an integer sample position with `(ulong)(value.Timestamp * _sampleRateInOptions)`, **truncating** the value.

This round-trip shifts the position by -1 for roughly 5% of frames. The recently added discrete-timestamp handling (`forward_audio_discontinuity`, zero tolerance) then detects a false forward gap of 1 sample and inserts silence. This adds click noise to continuous audio, and the growing stream length causes audio to drift slightly behind video.

## Fix

Adopt the essential fix: carry the integer sample position all the way to the FFI boundary without going through `double`. Investigation showed the write and read sites of `PcmAudioFrame.Timestamp` are one each, and `PcmAudioFrame` does not implement `IDiscreteTemporalData` — no other part of the pipeline (including drop decisions) references `Timestamp` — so the blast radius is minimal.

- Add `long SamplePosition` to `PcmAudioFrame` (keep `Timestamp`).
- `AudioTemporalAdjuster` carries the integer sample position directly.
- `AudioEncoderInput` uses `(ulong)value.SamplePosition`; the now-unused `_sampleRateInOptions` and its constructor argument are removed.
- Updated the two call sites (`RealtimeInstantReplaySession` / `UnboundedRecordingSession`).

## Verification

- Numerical simulation (faithfully reproducing the C# double math/truncation and the Rust-side gap detection, 200k frames each): pre-fix, 4.0% of frames at 44.1kHz and 5.7% at 48kHz produced false gaps. Post-fix: **0 in all scenarios**.
- Unity Play Mode: recorded ~183s in SampleScene including audio toggles, then exported. ffprobe shows **all 8582 AAC packets at exactly 21.333ms intervals**, zero gaps > 32ms. Audio 183.081s vs video 183.091s match within 10ms (A/V sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
