### PR TITLE
Fix race in PooledHandle.MoveOut returning handle after pooling

### DIFF
--- a/Packages/jp.co.cyberagent.instant-replay/UniEnc/Runtime/Internal/PooledHandle.cs
+++ b/Packages/jp.co.cyberagent.instant-replay/UniEnc/Runtime/Internal/PooledHandle.cs
@@ -40,10 +40,14 @@ namespace UniEnc
 
             Reset();
 
+            // Capture the handle before publishing this instance to the pool;
+            // once pooled, another thread may rent it and overwrite the handle field.
+            var movedHandle = handle;
+
             if (++Token < ushort.MaxValue)
                 AddToPool();
 
-            return handle;
+            return movedHandle;
         }
 
         protected abstract void AddToPool();


### PR DESCRIPTION
## Summary

`PooledHandle.MoveOut(ushort token)` read and returned the SafeHandle `handle` field **after** publishing the instance to the static pool via `AddToPool()`.

```csharp
if (++Token < ushort.MaxValue)
    AddToPool();   // another thread can rent it from here
return handle;     // ← may return an overwritten handle
```

If another thread rents the instance from the pool and calls `SetHandleForPooledHandle()` (internally `SetHandle()`), `handle` is overwritten with a different buffer's pointer, so `MoveOut` returns the wrong pointer (frame corruption). Via `MoveOutAndRelease`, this becomes a double-free / use-after-free of a buffer still in use.

In `RealtimeInstantReplaySession`, the main thread rents Handles from the pool while an encoder-consumer task on a `Task` runs `MoveOut`, so this race can actually occur.

## Fix

Save `handle` into a local variable before calling `AddToPool()`, and return the local. Since `MoveOutAndRelease` uses the return value of `MoveOut`, the double-free / UAF path is resolved at the same time.

Verified the sole derived class (`SharedBuffer<T>.Handle`) and the ordering in `ReleaseHandle` / `SetHandleForPooledHandle`; no other instance of this ordering problem exists.

## Verification

- `dotnet build` (netstandard2.0 / netstandard2.1 / net5.0): 0 warnings, 0 errors.
- Unity Play Mode: ~183s record → export completed with zero errors (this path can trigger the race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
