### PR TITLE
fix: avoid Tokio timer in Android video encoder input retry

### DIFF
--- a/InstantReplay.Externals/unienc/crates/unienc_android_mc/Cargo.toml
+++ b/InstantReplay.Externals/unienc/crates/unienc_android_mc/Cargo.toml
@@ -8,7 +8,7 @@ authors.workspace = true
 [dependencies]
 thiserror = { workspace = true }
 jni = "0.21.1"
-tokio = { version = "1.45.1", features = ["time", "sync"] }
+tokio = { version = "1.45.1", features = ["sync"] }
 unienc_common = { workspace = true, features = ["unity"] }
 bincode = { workspace = true }
 ndk-sys = { version = "0.6.0", features = ["media"] }

--- a/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/video/mod.rs
+++ b/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/video/mod.rs
@@ -210,7 +210,7 @@ async fn push_video_impl<R: unienc_common::Runtime + 'static>(
                     }
                 }
                 if sleep {
-                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    yield_now().await;
                 }
             }
 


### PR DESCRIPTION
## Problem

Recording on Android intermittently aborts the process with `SIGABRT`, preceded by a panic from `unienc_android_mc`:

Fixes #167.

## Cause

`push_video_impl()` awaited `tokio::time::sleep()` when `MediaCodec.dequeueInputBuffer()` returned `INFO_TRY_AGAIN_LATER`. Since 31793a1 the encoder futures are driven by `futures::executor::ThreadPool` (see `unienc_c/src/runtime.rs`); there is no Tokio runtime anywhere in the workspace, so the Tokio timer cannot find a reactor and panics. The release profile uses `panic = "abort"`, which turns the panic into `SIGABRT`.

The call site is only reachable when both of the following hold, which is why the crash is intermittent and why it has gone unnoticed on many devices:

1. The `VideoFrame::Bgra32` (CPU readback) path is selected. `is_blit_supported()` requires `api_level >= 29 && vulkan::is_initialized()`, so any device not running on Vulkan falls back to readback, as does any caller that sets `ForceReadback`.
2. No MediaCodec input buffer becomes available for 100 ms straight. A hardware encoder recycles input buffers within a few milliseconds at ordinary frame rates, so this only occurs when the encoder stalls, which is far more likely with a software encoder or under heavy load.

The corresponding retry on the output side (`common.rs`) already used the runtime-agnostic `yield_now()`; only the input side was left on a Tokio timer.

## Fix

- Replace `tokio::time::sleep()` with the existing runtime-agnostic `yield_now()`. `dequeue_input_buffer()` already blocks for up to 100 ms per attempt, so the retry loop keeps its backoff and does not busy-spin.
- Drop the now-unused `time` feature from the `tokio` dependency of `unienc_android_mc`, so that reintroducing `tokio::time` fails at compile time instead of panicking at runtime.

## Verification

- `cargo ndk -t aarch64-linux-android --platform 26 check` passes without warnings.
- The panic was reproduced outside of Unity with a minimal program that awaits `tokio::time::sleep()` on a `futures::executor::ThreadPool`, yielding the identical panic message. The same harness completes 1000 iterations of `yield_now()` without panicking.