### PR TITLE
Fix the WebCodecs backend, which has never encoded audio

### DIFF
--- a/InstantReplay.Externals/unienc/crates/unienc_webcodecs/src/js/library.ts
+++ b/InstantReplay.Externals/unienc/crates/unienc_webcodecs/src/js/library.ts
@@ -150,26 +150,49 @@ window["unienc_webcodecs"] = {
         EncodedVideoChunk
     >({
         createEncoder: async (options, onChunk) => {
-            const config: VideoEncoderConfig = {
-                codec: "avc1.640028",
-                width: options.width,
-                height: options.height,
-                bitrate: options.bitrate,
-                framerate: options.framerate,
-                avc: {
-                    format: "annexb",
-                }
-            };
+            // Which H.264 profiles a browser will encode is not fixed: Chrome on
+            // Linux, for one, refuses High. Asking for a single profile means
+            // failing outright wherever it is missing, so these are tried in
+            // descending order of what they buy and the first the browser accepts
+            // is used. Baseline is the most widely playable of the three, so the
+            // fallback costs compression rather than compatibility.
+            //
+            // `isConfigSupported` resolves to a support object rather than a
+            // boolean, so `supported` has to be read from it; negating the object
+            // is always false and lets an unsupported configuration through to
+            // `configure`, where the encoder closes itself and the first `encode`
+            // fails with an unrelated InvalidStateError.
+            const profiles = [
+                "avc1.640028", // High, level 4.0
+                "avc1.4d0028", // Main, level 4.0
+                "avc1.42001f", // Baseline, level 3.1
+            ];
 
-            // `isConfigSupported` resolves to a support object, not a
-            // boolean; negating the object was always false, so an unsupported
-            // configuration went straight on to `configure`. The encoder then
-            // closed itself asynchronously and the first `encode` failed with an
-            // unrelated InvalidStateError.
-            const support = await VideoEncoder.isConfigSupported(config);
-            if (!support.supported) {
+            let config: VideoEncoderConfig | null = null;
+            for (const codec of profiles) {
+                const candidate: VideoEncoderConfig = {
+                    codec,
+                    width: options.width,
+                    height: options.height,
+                    bitrate: options.bitrate,
+                    framerate: options.framerate,
+                    avc: {
+                        format: "annexb",
+                    }
+                };
+                // The candidate is kept rather than the normalized config the
+                // browser returns, because the muxer depends on the annexb
+                // format and a sanitized config need not preserve it.
+                if ((await VideoEncoder.isConfigSupported(candidate)).supported) {
+                    config = candidate;
+                    break;
+                }
+            }
+
+            if (!config) {
                 throw new Error(
-                    `The video encoder configuration is not supported: ${JSON.stringify(config)}`);
+                    `No supported H.264 profile for ${options.width}x${options.height}`
+                    + ` at ${options.bitrate} bps; tried ${profiles.join(", ")}`);
             }
             const init: VideoEncoderInit = {
                 output: (chunk, metadata) => {

--- a/InstantReplay.Externals/unienc/crates/unienc_webcodecs/src/js/library.ts
+++ b/InstantReplay.Externals/unienc/crates/unienc_webcodecs/src/js/library.ts
@@ -161,8 +161,15 @@ window["unienc_webcodecs"] = {
                 }
             };
 
-            if (!await VideoEncoder.isConfigSupported(config)) {
-                throw new Error("The specified video encoder configuration is not supported.");
+            // `isConfigSupported` resolves to a support object, not a
+            // boolean; negating the object was always false, so an unsupported
+            // configuration went straight on to `configure`. The encoder then
+            // closed itself asynchronously and the first `encode` failed with an
+            // unrelated InvalidStateError.
+            const support = await VideoEncoder.isConfigSupported(config);
+            if (!support.supported) {
+                throw new Error(
+                    `The video encoder configuration is not supported: ${JSON.stringify(config)}`);
             }
             const init: VideoEncoderInit = {
                 output: (chunk, metadata) => {
@@ -232,8 +239,11 @@ window["unienc_webcodecs"] = {
                 },
             };
 
-            if (!await AudioEncoder.isConfigSupported(config)) {
-                throw new Error("The specified video encoder configuration is not supported.");
+            // See the note on the video encoder above.
+            const support = await AudioEncoder.isConfigSupported(config);
+            if (!support.supported) {
+                throw new Error(
+                    `The audio encoder configuration is not supported: ${JSON.stringify(config)}`);
             }
             const init: AudioEncoderInit = {
                 output: (chunk, _metadata) => {

--- a/InstantReplay.Externals/unienc/crates/unienc_webcodecs/src/js/library.ts
+++ b/InstantReplay.Externals/unienc/crates/unienc_webcodecs/src/js/library.ts
@@ -223,6 +223,13 @@ window["unienc_webcodecs"] = {
                 bitrate: options.bitrate,
                 numberOfChannels: options.channels,
                 sampleRate: options.sampleRate,
+                // The muxer takes ADTS framed AAC, as the other backends
+                // produce. Without this the encoder emits raw AAC and the
+                // muxer rejects every frame for having no header. This is the
+                // audio counterpart of the annexb format asked for above.
+                aac: {
+                    format: "adts",
+                },
             };
 
             if (!await AudioEncoder.isConfigSupported(config)) {

--- a/InstantReplay.Externals/unienc/crates/unienc_webcodecs/src/js/mod.rs
+++ b/InstantReplay.Externals/unienc/crates/unienc_webcodecs/src/js/mod.rs
@@ -1,7 +1,7 @@
 use crate::emscripten::run_script;
 use futures::channel::oneshot;
 use futures::channel::oneshot::Canceled;
-use std::ffi::{CString, c_char};
+use std::ffi::{CStr, CString, c_char};
 use std::sync::LazyLock;
 use thiserror::Error;
 
@@ -103,7 +103,9 @@ pub fn make_download(parts: &[Vec<u8>], mime: &str, filename: &str) {
 
 #[derive(Error, Debug)]
 pub enum JavaScriptError {
-    #[error("JavaScript execution error")]
+    // The captured message is the only description of what the browser
+    // rejected, so it has to reach the caller.
+    #[error("JavaScript execution error: {0}")]
     ExecutionError(String),
     #[error("JavaScript async completion canceled")]
     AsyncExecutionError(#[from] Canceled),
@@ -120,9 +122,11 @@ impl Library {
     fn run_script(&self, script: &str) -> Result<(), JavaScriptError> {
         extern "system" fn on_error_fn(msg: *const c_char, ctx: *mut Option<JavaScriptError>) {
             unsafe {
-                *ctx = msg
-                    .as_ref()
-                    .map(|msg| JavaScriptError::ExecutionError(msg.to_string()));
+                *ctx = (!msg.is_null()).then(|| {
+                    JavaScriptError::ExecutionError(
+                        CStr::from_ptr(msg).to_string_lossy().into_owned(),
+                    )
+                });
             }
         }
 
@@ -156,10 +160,11 @@ impl Library {
         ) {
             unsafe {
                 Box::from_raw(ctx)
-                    .send(
-                        msg.as_ref()
-                            .map(|msg| JavaScriptError::ExecutionError(msg.to_string())),
-                    )
+                    .send((!msg.is_null()).then(|| {
+                        JavaScriptError::ExecutionError(
+                            CStr::from_ptr(msg).to_string_lossy().into_owned(),
+                        )
+                    }))
                     .unwrap();
             }
         }
@@ -325,12 +330,12 @@ impl Library {
             "
             const bitrate = {bitrate};
             const channels = {channels};
-            const sample_rate = {sample_rate};
+            const sampleRate = {sample_rate};
             const onOutput = {on_output};
             const onOutputCtx = {on_output_ctx};
             const onComplete = {on_complete};
             const onCompleteCtx = {on_complete_ctx};
-            window.unienc_webcodecs.video.new({{ bitrate, channels, sample_rate }}, onOutput, onOutputCtx, onComplete, onCompleteCtx);
+            await window.unienc_webcodecs.audio.new({{ bitrate, channels, sampleRate }}, onOutput, onOutputCtx, onComplete, onCompleteCtx);
             "
         );
         self.run_script_async(&script).await?;
@@ -354,10 +359,10 @@ impl Library {
             const dataPtr = {data_ptr};
             const dataLength = {data_length};
             const channels = {channels};
-            const sample_rate = {sample_rate};
+            const sampleRate = {sample_rate};
             const timestamp = {timestamp};
             const dataArray = new Uint8Array(Module.HEAPU8.buffer, dataPtr, dataLength);
-            window.unienc_webcodecs.video.push(encoderIndex, dataArray, {{channels, sample_rate, timestamp}});
+            window.unienc_webcodecs.audio.push(encoderIndex, dataArray, {{channels, sampleRate, timestamp}});
             ",
             data_ptr = data.as_ptr() as usize,
             data_length = data.len(),

--- a/InstantReplay.Externals/unienc/crates/unienc_webcodecs/src/mux/mod.rs
+++ b/InstantReplay.Externals/unienc/crates/unienc_webcodecs/src/mux/mod.rs
@@ -40,23 +40,82 @@ impl Write for FragmentWrite {
     }
 }
 
+/// The muxer, together with the audio it is not ready for yet.
+///
+/// muxide refuses audio until a video frame has been written, and the pipeline
+/// feeds both streams concurrently, so which one produces output first is up to
+/// the encoders rather than up to us. Audio that arrives early is held here and
+/// written as soon as the first video frame lands, which keeps the ordering
+/// requirement inside the muxer instead of imposing it on every caller.
+///
+/// The backlog only spans the gap before the first video frame, which is a frame
+/// interval in the ordinary case.
+struct PendingMuxer {
+    /// `None` once the muxer has been finished.
+    muxer: Option<muxide::api::Muxer<FragmentWrite>>,
+    /// Audio waiting for a video frame to make it acceptable.
+    pending_audio: Vec<AudioEncodedData>,
+    video_written: bool,
+}
+
+impl PendingMuxer {
+    fn new(muxer: muxide::api::Muxer<FragmentWrite>) -> Self {
+        Self {
+            muxer: Some(muxer),
+            pending_audio: Vec::new(),
+            video_written: false,
+        }
+    }
+
+    fn get(&mut self) -> unienc_common::Result<&mut muxide::api::Muxer<FragmentWrite>> {
+        self.muxer.as_mut().context("The muxer is already finished")
+    }
+
+    fn write_video(&mut self, data: &VideoEncodedData) -> unienc_common::Result<()> {
+        self.get()?
+            .write_video(data.timestamp(), &data.data, data.is_key)
+            .context("Failed to write encoded frame")?;
+        self.video_written = true;
+
+        // Anything held back is now acceptable, and goes in before any later
+        // audio so that the stream stays in order.
+        for data in std::mem::take(&mut self.pending_audio) {
+            self.get()?
+                .write_audio(data.timestamp(), &data.data)
+                .context("Failed to write held back audio frame")?;
+        }
+        Ok(())
+    }
+
+    fn write_audio(&mut self, data: AudioEncodedData) -> unienc_common::Result<()> {
+        if !self.video_written {
+            self.pending_audio.push(data);
+            return Ok(());
+        }
+        self.get()?
+            .write_audio(data.timestamp(), &data.data)
+            .context("Failed to write encoded frame")?;
+        Ok(())
+    }
+}
+
 pub struct WebCodecsMuxer {
     video: WebCodecsVideoInput,
     audio: WebCodecsAudioInput,
     completion: WebCodecsCompletionHandle,
 }
 pub struct WebCodecsVideoInput {
-    muxer: Arc<Mutex<Option<muxide::api::Muxer<FragmentWrite>>>>,
+    muxer: Arc<Mutex<PendingMuxer>>,
     finish_tx: Option<oneshot::Sender<()>>,
 }
 pub struct WebCodecsAudioInput {
-    muxer: Arc<Mutex<Option<muxide::api::Muxer<FragmentWrite>>>>,
+    muxer: Arc<Mutex<PendingMuxer>>,
     finish_tx: Option<oneshot::Sender<()>>,
 }
 pub struct WebCodecsCompletionHandle {
     filename: String,
     writer: FragmentWrite,
-    muxer: Arc<Mutex<Option<muxide::api::Muxer<FragmentWrite>>>>,
+    muxer: Arc<Mutex<PendingMuxer>>,
     video_finish_rx: Option<oneshot::Receiver<()>>,
     audio_finish_rx: Option<oneshot::Receiver<()>>,
 }
@@ -74,7 +133,7 @@ impl WebCodecsMuxer {
             .to_string_lossy()
             .to_string();
 
-        let muxer = Arc::new(Mutex::new(Some(
+        let muxer = Arc::new(Mutex::new(PendingMuxer::new(
             MuxerBuilder::new(writer.clone())
                 .video(
                     VideoCodec::H264,
@@ -135,12 +194,7 @@ impl MuxerInput for WebCodecsVideoInput {
     type Data = VideoEncodedData;
 
     async fn push(&mut self, data: Self::Data) -> unienc_common::Result<()> {
-        let mut muxer_guard = self.muxer.lock().unwrap();
-        let muxer = muxer_guard.as_mut().unwrap();
-        muxer
-            .write_video(data.timestamp(), &data.data, data.is_key)
-            .context("Failed to write encoded frame")?;
-        Ok(())
+        self.muxer.lock().unwrap().write_video(&data)
     }
 
     async fn finish(mut self) -> unienc_common::Result<()> {
@@ -157,12 +211,7 @@ impl MuxerInput for WebCodecsAudioInput {
     type Data = AudioEncodedData;
 
     async fn push(&mut self, data: Self::Data) -> unienc_common::Result<()> {
-        let mut muxer_guard = self.muxer.lock().unwrap();
-        let muxer = muxer_guard.as_mut().unwrap();
-        muxer
-            .write_audio(data.timestamp(), &data.data)
-            .context("Failed to write encoded frame")?;
-        Ok(())
+        self.muxer.lock().unwrap().write_audio(data)
     }
 
     async fn finish(mut self) -> unienc_common::Result<()> {
@@ -182,7 +231,19 @@ impl CompletionHandle for WebCodecsCompletionHandle {
             self.audio_finish_rx.take().unwrap()
         );
         let mut muxer_guard = self.muxer.lock().unwrap();
-        let muxer = muxer_guard.take().unwrap();
+        // Held back audio can only be written after a video frame, so if any is
+        // still waiting there never was one and the output would be silent
+        // without saying so.
+        if !muxer_guard.pending_audio.is_empty() {
+            return Err(CommonError::Other(format!(
+                "no video frame was ever written, so {} audio frame(s) could not be muxed",
+                muxer_guard.pending_audio.len()
+            )));
+        }
+        let muxer = muxer_guard
+            .muxer
+            .take()
+            .context("The muxer is already finished")?;
         muxer.finish().context("Failed to finish audio")?;
 
         self.writer


### PR DESCRIPTION
## Problem

The web backend could not be run outside Unity, so eight defects went unnoticed. Together they meant it **never produced audio at all**, and would not encode video wherever the browser declined High profile.

1. `new_audio_encoder` and `push_audio_frame` built scripts calling `window.unienc_webcodecs.video.*` rather than `audio.*`, so audio samples went to the video encoder. `flush_audio` and `free_audio_encoder` had it right, which suggests where the copy came from.
2. The audio scripts declared `sample_rate` where `library.ts` reads `options.sampleRate`, so the browser saw an `AudioEncoderConfig` missing a required member and rejected it.
3. `new_audio_encoder` did not await the encoder's creation, so a rejection had nowhere to surface and the caller waited instead of failing.
4. `JavaScriptError::ExecutionError` discarded the message it carried, and the callback that captured it read `*const c_char` as a reference to one byte and formatted that byte's value. The rejection above arrived as the text `84` — the first character of `TypeError`.
5. The muxer refused audio arriving before the first video frame. The pipeline feeds both streams concurrently, so which produces output first is up to the encoders; on the web the audio encoder wins and the whole mux failed.
6. WebCodecs emits raw AAC by default while the muxer validates an ADTS header, so every frame was rejected for being six bytes short of one.
7. `isConfigSupported` resolves to a support object, which is always truthy, so `!await ...` never fired. An unsupported configuration went straight on to `configure`; the encoder closed itself asynchronously and the first `encode` failed with an InvalidStateError about a closed codec — an error that says nothing about the cause.
8. The H.264 profile was fixed at `avc1.640028`. Chrome on Linux will not encode High, so the backend failed outright there. This is what the browser job in CI hit, and 7 is why it reported the wrong thing.

## What this does

Fixes 1–4 in the JavaScript bridge. For 5, early audio is held inside `WebCodecsMuxer` and written as soon as the first video frame lands, so the ordering requirement stays in the muxer rather than being imposed on callers; finishing with audio still held is reported as an error rather than silently producing a file with no sound. For 6, the encoder is asked for ADTS framing — the audio counterpart of the annexb format the video config already requests. For 7, `supported` is read from the result and the configuration goes into the message. For 8, the profiles are tried in descending order of what they buy — High, then Main, then Baseline — and the first the browser accepts is used; Baseline is the most widely playable of the three, so falling back costs compression rather than compatibility.

## Verification

Run in headless Chrome with the harness added by the next PR in the stack: ten video frames and ten seconds of audio in, an MP4 with both tracks starting at zero out. A browser that supports High still gets High — confirmed by reading the profile back out of `avcC` — and inserting a profile the browser refuses makes the run fall through to the next one and pass.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)