### PR TITLE
Stop the Android backend from holding the executor's workers

### DIFF
--- a/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/audio/mod.rs
+++ b/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/audio/mod.rs
@@ -10,12 +10,12 @@ use crate::{
 
 use crate::java::*;
 
-pub struct MediaCodecAudioEncoder {
-    input: MediaCodecAudioEncoderInput,
-    output: MediaCodecAudioEncoderOutput,
+pub struct MediaCodecAudioEncoder<R: unienc_common::Runtime + 'static> {
+    input: MediaCodecAudioEncoderInput<R>,
+    output: MediaCodecAudioEncoderOutput<R>,
 }
 
-pub struct MediaCodecAudioEncoderInput {
+pub struct MediaCodecAudioEncoderInput<R: unienc_common::Runtime + 'static> {
     codec: MediaCodec,
     sample_rate: u32,
     channels: u32,
@@ -28,26 +28,28 @@ pub struct MediaCodecAudioEncoderInput {
     /// Expected input timestamp (in samples) of the next push, i.e. the previous push's timestamp plus
     /// the number of frames it delivered. Used to detect discontinuities in the input timeline.
     next_input_position: Option<u64>,
+    runtime: R,
 }
 
-unsafe impl Send for MediaCodecAudioEncoderInput {}
+unsafe impl<R: unienc_common::Runtime + 'static> Send for MediaCodecAudioEncoderInput<R> {}
 
-pub struct MediaCodecAudioEncoderOutput {
+pub struct MediaCodecAudioEncoderOutput<R: unienc_common::Runtime + 'static> {
     codec: MediaCodec,
     end_of_stream: bool,
+    runtime: R,
 }
 
-impl Encoder for MediaCodecAudioEncoder {
-    type InputType = MediaCodecAudioEncoderInput;
-    type OutputType = MediaCodecAudioEncoderOutput;
+impl<R: unienc_common::Runtime + 'static> Encoder for MediaCodecAudioEncoder<R> {
+    type InputType = MediaCodecAudioEncoderInput<R>;
+    type OutputType = MediaCodecAudioEncoderOutput<R>;
 
     fn get(self) -> unienc_common::Result<(Self::InputType, Self::OutputType)> {
         Ok((self.input, self.output))
     }
 }
 
-impl MediaCodecAudioEncoder {
-    pub fn new<A: unienc_common::AudioEncoderOptions>(options: &A) -> Result<Self> {
+impl<R: unienc_common::Runtime + 'static> MediaCodecAudioEncoder<R> {
+    pub fn new<A: unienc_common::AudioEncoderOptions>(options: &A, runtime: R) -> Result<Self> {
         let env = &mut attach_current_thread()?;
 
         // Create MediaFormat
@@ -74,19 +76,26 @@ impl MediaCodecAudioEncoder {
                 last_timestamp: 0,
                 position_in_samples: None,
                 next_input_position: None,
+                runtime: runtime.clone(),
             },
             output: MediaCodecAudioEncoderOutput {
                 codec: codec_output,
                 end_of_stream: false,
+                runtime,
             },
         })
     }
 }
 
-impl Drop for MediaCodecAudioEncoderInput {
+impl<R: unienc_common::Runtime + 'static> Drop for MediaCodecAudioEncoderInput<R> {
     fn drop(&mut self) {
         // notify end of stream
         || -> Result<()> {
+            // `Drop` cannot await, so this one wait stays on the calling
+            // thread. It is bounded and happens once per stream, unlike the
+            // per-buffer waits in `push`, but it is the same shape: if the
+            // codec has no free input buffer it needs the pull task to
+            // release an output buffer, and that task needs a worker.
             loop {
                 let buffer_index = self
                     .codec
@@ -112,7 +121,7 @@ impl Drop for MediaCodecAudioEncoderInput {
     }
 }
 
-impl EncoderInput for MediaCodecAudioEncoderInput {
+impl<R: unienc_common::Runtime + 'static> EncoderInput for MediaCodecAudioEncoderInput<R> {
     type Data = AudioSample;
 
     async fn push(&mut self, data: Self::Data) -> unienc_common::Result<()> {
@@ -120,7 +129,10 @@ impl EncoderInput for MediaCodecAudioEncoderInput {
     }
 }
 
-async fn push_impl(this: &mut MediaCodecAudioEncoderInput, data: AudioSample) -> Result<()> {
+async fn push_impl<R: unienc_common::Runtime + 'static>(
+    this: &mut MediaCodecAudioEncoderInput<R>,
+    data: AudioSample,
+) -> Result<()> {
     // Keep the encoded audio contiguous in sample-count terms (see the Apple backend for the rationale):
     // when the input timeline jumps forward (dropped or suspended audio that advances `timestamp_in_samples`
     // by more than the number of samples actually delivered), fill the gap with leading silence so
@@ -149,10 +161,11 @@ async fn push_impl(this: &mut MediaCodecAudioEncoderInput, data: AudioSample) ->
     let mut byte_data = byte_data.as_slice();
 
     while !byte_data.is_empty() {
-        // Get input buffer
-        let buffer_index = this
-            .codec
-            .dequeue_input_buffer(Duration::from_millis(100))?;
+        // Get input buffer. The wait happens on the blocking pool so that this
+        // task does not hold an executor worker while the codec has nothing to
+        // give; see `dequeue_input_buffer_off_executor`.
+        let buffer_index =
+            dequeue_input_buffer_off_executor(&this.runtime, &this.codec, DEQUEUE_TIMEOUT).await?;
         if buffer_index >= 0 {
             let input_buffer = this.codec.get_input_buffer(buffer_index)?;
             {
@@ -190,7 +203,7 @@ async fn push_impl(this: &mut MediaCodecAudioEncoderInput, data: AudioSample) ->
                 this.position_in_samples = Some(position_in_samples + frames_written);
             }
         } else if buffer_index == media_codec_errors::INFO_TRY_AGAIN_LATER {
-            std::thread::sleep(Duration::from_millis(10));
+            // The dequeue above already waited, so retry straight away.
             continue;
         } else {
             return Err(AndroidError::NoInputBuffer);
@@ -200,11 +213,11 @@ async fn push_impl(this: &mut MediaCodecAudioEncoderInput, data: AudioSample) ->
     Ok(())
 }
 
-impl EncoderOutput for MediaCodecAudioEncoderOutput {
+impl<R: unienc_common::Runtime + 'static> EncoderOutput for MediaCodecAudioEncoderOutput<R> {
     type Data = CommonEncodedData;
 
     async fn pull(&mut self) -> unienc_common::Result<Option<Self::Data>> {
-        pull_encoded_data_with_codec(&self.codec, &mut self.end_of_stream)
+        pull_encoded_data_with_codec(self.runtime.clone(), &self.codec, &mut self.end_of_stream)
             .await
             .map_err(Into::into)
     }

--- a/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/common.rs
+++ b/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/common.rs
@@ -4,10 +4,10 @@ use jni::{
     objects::{JObject, JString},
     sys::{jint, jlong},
 };
+use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
 use std::{collections::HashMap, fmt::Display, sync::Arc, time::Duration};
-use unienc_common::{EncodedData, UniencSampleKind, VideoFrameBgra32};
+use unienc_common::{EncodedData, SpawnBlocking, UniencSampleKind, VideoFrameBgra32};
 
 use crate::bindings;
 use crate::error::{AndroidError, Result};
@@ -533,82 +533,109 @@ impl EncodedData for CommonEncodedData {
     }
 }
 
-pub(crate) async fn pull_encoded_data_with_codec(
+/// How long a MediaCodec dequeue is allowed to block before it is retried.
+///
+/// The call runs on the blocking pool rather than on an executor worker, so the
+/// wait costs nothing but a parked thread, and a real timeout is what keeps the
+/// retry loop from becoming a busy loop.
+pub(crate) const DEQUEUE_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Waits for a MediaCodec input buffer without occupying an executor worker.
+///
+/// `MediaCodec.dequeueInputBuffer` blocks its calling thread for up to the
+/// timeout. Awaited directly from a task, it therefore holds the worker the task
+/// is running on, and the executor has no more workers than the machine has
+/// cores. On a two-core device the two push tasks hold both, the pull tasks that
+/// release the codec's output buffers never run, the codec never frees an input
+/// buffer, and the push tasks wait forever. Handing the call to the blocking pool
+/// parks the task instead, which leaves the worker free for the rest of the
+/// pipeline.
+///
+/// Returns an owned future rather than being an `async fn` so that no borrow of
+/// the runtime is held across the await; `Runtime` is `Send` but not `Sync`.
+pub(crate) fn dequeue_input_buffer_off_executor<R: SpawnBlocking>(
+    runtime: &R,
+    codec: &MediaCodec,
+    timeout: Duration,
+) -> Pin<Box<dyn Future<Output = Result<jint>> + Send + 'static>> {
+    let codec = codec.clone();
+    runtime.spawn_blocking(move || codec.dequeue_input_buffer(timeout))
+}
+
+/// The output-side counterpart of [`dequeue_input_buffer_off_executor`], for the
+/// same reason.
+pub(crate) fn dequeue_output_buffer_off_executor<R: SpawnBlocking>(
+    runtime: &R,
+    codec: &MediaCodec,
+    buffer_info: &SafeGlobalRef,
+    timeout: Duration,
+) -> Pin<Box<dyn Future<Output = Result<jint>> + Send + 'static>> {
+    let codec = codec.clone();
+    let buffer_info = buffer_info.clone();
+    let timeout_us = timeout.as_micros() as i64;
+    runtime.spawn_blocking(move || codec.dequeue_output_buffer(&buffer_info, timeout_us))
+}
+
+/// Takes the codec's runtime by value rather than by reference because the
+/// future has to be `Send` and `Runtime` is not `Sync`.
+pub(crate) async fn pull_encoded_data_with_codec<R: SpawnBlocking>(
+    runtime: R,
     codec: &MediaCodec,
     end_of_stream: &mut bool,
 ) -> Result<Option<CommonEncodedData>> {
     if *end_of_stream {
         return Ok(None);
     }
+
+    // One `BufferInfo` serves every iteration: `dequeueOutputBuffer` overwrites
+    // its fields on each successful call.
+    let buffer_info = {
+        let env = &mut attach_current_thread()?;
+        create_buffer_info(env)?
+    };
+
     loop {
-        let mut sleep = false;
-        {
+        let buffer_index =
+            dequeue_output_buffer_off_executor(&runtime, codec, &buffer_info, DEQUEUE_TIMEOUT)
+                .await?;
+
+        if buffer_index >= 0 {
             let env = &mut attach_current_thread()?;
-            let buffer_info = create_buffer_info(env)?;
-            let buffer_index = codec.dequeue_output_buffer(&buffer_info, 0)?;
+            let output_buffer = codec.get_output_buffer(buffer_index)?;
+            let (offset, size, flags, timestamp) = read_buffer_info_common(env, &buffer_info)?;
 
-            if buffer_index >= 0 {
-                let output_buffer = codec.get_output_buffer(buffer_index)?;
-                let (offset, size, flags, timestamp) = read_buffer_info_common(env, &buffer_info)?;
+            // Read encoded data
+            let encoded_data = read_from_buffer(env, &output_buffer, offset, size)?;
 
-                // Read encoded data
-                let encoded_data = read_from_buffer(env, &output_buffer, offset, size)?;
+            let video_data = CommonEncodedData {
+                content: CommonEncodedDataContent::Buffer {
+                    data: encoded_data,
+                    buffer_flag: flags,
+                },
+                timestamp: timestamp as f64 / 1_000_000.0, // Convert from microseconds
+            };
 
-                // println!("new frame data: is_video: {}, flags: {:?}, length: {}, timestamp: {}, offset: {}, {:?}", is_video, flags, encoded_data.len(), timestamp, offset, encoded_data.iter().take(32).collect::<Vec<_>>());
+            codec.release_output_buffer(buffer_index, false)?;
 
-                let video_data = CommonEncodedData {
-                    content: CommonEncodedDataContent::Buffer {
-                        data: encoded_data,
-                        buffer_flag: flags,
-                    },
-                    timestamp: timestamp as f64 / 1_000_000.0, // Convert from microseconds
-                };
-
-                codec.release_output_buffer(buffer_index, false)?;
-
-                if (flags & media_codec_buffer_flag::BUFFER_FLAG_END_OF_STREAM) != 0 {
-                    *end_of_stream = true;
-                }
-                return Ok(Some(video_data));
-            } else if buffer_index == media_codec_errors::INFO_TRY_AGAIN_LATER {
-                sleep = true;
-            } else if buffer_index == media_codec_errors::INFO_OUTPUT_FORMAT_CHANGED {
-                let map = codec.get_output_format()?;
-
-                let metadata = CommonEncodedData {
-                    content: CommonEncodedDataContent::FormatInfo(map),
-                    timestamp: 0.0,
-                };
-                return Ok(Some(metadata));
+            if (flags & media_codec_buffer_flag::BUFFER_FLAG_END_OF_STREAM) != 0 {
+                *end_of_stream = true;
             }
+            return Ok(Some(video_data));
         }
-        if sleep {
-            yield_now().await;
+
+        if buffer_index == media_codec_errors::INFO_OUTPUT_FORMAT_CHANGED {
+            let map = codec.get_output_format()?;
+
+            let metadata = CommonEncodedData {
+                content: CommonEncodedDataContent::FormatInfo(map),
+                timestamp: 0.0,
+            };
+            return Ok(Some(metadata));
         }
+
+        // Anything else, `INFO_TRY_AGAIN_LATER` included, means there is nothing
+        // to take yet. The dequeue above already waited, so retry straight away.
     }
-}
-pub async fn yield_now() {
-    struct YieldNow {
-        yielded: bool,
-    }
-
-    impl Future for YieldNow {
-        type Output = ();
-
-        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-            if self.yielded {
-                return Poll::Ready(());
-            }
-
-            self.yielded = true;
-
-            cx.waker().wake_by_ref();
-
-            Poll::Pending
-        }
-    }
-
-    YieldNow { yielded: false }.await;
 }
 
 pub(crate) fn format_to_map(

--- a/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/lib.rs
+++ b/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/lib.rs
@@ -52,7 +52,7 @@ impl<
     type VideoEncoderOptionsType = V;
     type AudioEncoderOptionsType = A;
     type VideoEncoderType = MediaCodecVideoEncoder<R>;
-    type AudioEncoderType = MediaCodecAudioEncoder;
+    type AudioEncoderType = MediaCodecAudioEncoder<R>;
     type MuxerType = MediaMuxer;
     type BlitSourceType = VulkanTexture;
     type RuntimeType = R;
@@ -71,7 +71,8 @@ impl<
     }
 
     fn new_audio_encoder(&self) -> unienc_common::Result<Self::AudioEncoderType> {
-        MediaCodecAudioEncoder::new(&self.audio_options).map_err(Into::into)
+        MediaCodecAudioEncoder::<R>::new(&self.audio_options, self.runtime.clone())
+            .map_err(Into::into)
     }
 
     fn new_muxer(&self, output_path: &Path) -> unienc_common::Result<Self::MuxerType> {

--- a/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/video/mod.rs
+++ b/InstantReplay.Externals/unienc/crates/unienc_android_mc/src/video/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 
 pub struct MediaCodecVideoEncoder<R: unienc_common::Runtime + 'static> {
     input: MediaCodecVideoEncoderInput<R>,
-    output: MediaCodecVideoEncoderOutput,
+    output: MediaCodecVideoEncoderOutput<R>,
 }
 
 #[allow(dead_code)]
@@ -45,15 +45,16 @@ enum MediaCodecVideoEncoderInputProcessor {
 
 unsafe impl<R: unienc_common::Runtime + 'static> Send for MediaCodecVideoEncoderInput<R> {}
 
-pub struct MediaCodecVideoEncoderOutput {
+pub struct MediaCodecVideoEncoderOutput<R: unienc_common::Runtime + 'static> {
     codec: MediaCodec,
     end_of_stream: bool,
     initialization: Option<tokio::sync::oneshot::Receiver<()>>,
+    runtime: R,
 }
 
 impl<R: unienc_common::Runtime + 'static> Encoder for MediaCodecVideoEncoder<R> {
     type InputType = MediaCodecVideoEncoderInput<R>;
-    type OutputType = MediaCodecVideoEncoderOutput;
+    type OutputType = MediaCodecVideoEncoderOutput<R>;
 
     fn get(self) -> unienc_common::Result<(Self::InputType, Self::OutputType)> {
         Ok((self.input, self.output))
@@ -66,6 +67,11 @@ impl<R: unienc_common::Runtime + 'static> Drop for MediaCodecVideoEncoderInput<R
         || -> Result<()> {
             match &self.processor {
                 MediaCodecVideoEncoderInputProcessor::Uninitialized(_) => Ok(()),
+                // `Drop` cannot await, so this one wait stays on the calling
+                // thread. It is bounded and happens once per stream, unlike the
+                // per-buffer waits in `push`, but it is the same shape: if the
+                // codec has no free input buffer it needs the pull task to
+                // release an output buffer, and that task needs a worker.
                 MediaCodecVideoEncoderInputProcessor::Buffer() => loop {
                     let buffer_index = self
                         .codec
@@ -134,12 +140,13 @@ impl<R: unienc_common::Runtime + 'static> MediaCodecVideoEncoder<R> {
                         fps_hint: options.fps_hint(),
                     },
                 ),
-                runtime,
+                runtime: runtime.clone(),
             },
             output: MediaCodecVideoEncoderOutput {
                 codec: codec_output,
                 end_of_stream: false,
                 initialization: rx.into(),
+                runtime,
             },
         })
     }
@@ -193,26 +200,20 @@ async fn push_video_impl<R: unienc_common::Runtime + 'static>(
                 }
             }
 
-            let mut buffer_index;
-            loop {
-                let sleep;
-                {
-                    // Get input buffer
-                    buffer_index = this
-                        .codec
-                        .dequeue_input_buffer(Duration::from_millis(100))?;
-                    if buffer_index == media_codec_errors::INFO_TRY_AGAIN_LATER {
-                        sleep = true;
-                    } else if buffer_index < 0 {
-                        return Err(AndroidError::NoInputBuffer);
-                    } else {
-                        break;
-                    }
+            let buffer_index = loop {
+                // Get input buffer. The wait happens on the blocking pool so that
+                // this task does not hold an executor worker while the codec has
+                // nothing to give; see `dequeue_input_buffer_off_executor`.
+                let buffer_index =
+                    dequeue_input_buffer_off_executor(&this.runtime, &this.codec, DEQUEUE_TIMEOUT)
+                        .await?;
+                if buffer_index >= 0 {
+                    break buffer_index;
                 }
-                if sleep {
-                    yield_now().await;
+                if buffer_index != media_codec_errors::INFO_TRY_AGAIN_LATER {
+                    return Err(AndroidError::NoInputBuffer);
                 }
-            }
+            };
 
             let buffer = this.codec.get_input_buffer(buffer_index)?;
             let env = &mut attach_current_thread()?;
@@ -344,7 +345,7 @@ async fn push_video_impl<R: unienc_common::Runtime + 'static>(
     }
 }
 
-impl EncoderOutput for MediaCodecVideoEncoderOutput {
+impl<R: unienc_common::Runtime + 'static> EncoderOutput for MediaCodecVideoEncoderOutput<R> {
     type Data = CommonEncodedData;
 
     async fn pull(&mut self) -> unienc_common::Result<Option<Self::Data>> {
@@ -352,15 +353,15 @@ impl EncoderOutput for MediaCodecVideoEncoderOutput {
     }
 }
 
-async fn pull_video_output_impl(
-    this: &mut MediaCodecVideoEncoderOutput,
+async fn pull_video_output_impl<R: unienc_common::Runtime + 'static>(
+    this: &mut MediaCodecVideoEncoderOutput<R>,
 ) -> Result<Option<CommonEncodedData>> {
     if let Some(rx) = &mut this.initialization {
         rx.await?;
         this.initialization = None;
     }
 
-    pull_encoded_data_with_codec(&this.codec, &mut this.end_of_stream).await
+    pull_encoded_data_with_codec(this.runtime.clone(), &this.codec, &mut this.end_of_stream).await
 }
 
 // Helper functions for JNI MediaCodec calls


### PR DESCRIPTION
## Problem

The end-to-end harness deadlocks on Android whenever the executor has two
workers. It stops immediately after the video encoder accepts its first frame
and never recovers. GitHub's Linux runners have two cores, so the Android job
added by #179 hangs on every run.

`unienc_android_mc` waits for MediaCodec buffers in three loops, and none of them
releases the executor worker it is running on:

| Site | Wait |
| --- | --- |
| `audio::push_impl` | `std::thread::sleep(10 ms)` — blocks the worker outright |
| `video::push_video_impl` | `yield_now().await` |
| `common::pull_encoded_data_with_codec` | `yield_now().await` |

`yield_now` wakes its own waker from inside `poll` and returns `Pending`. On
`futures::executor::ThreadPool` that does not hand the worker to another task.
`UnparkMutex::notify` sees the task in `POLLING`, moves it to `REPOLL` and
returns `Err(())`, so nothing is queued; `Task::run` then gets `Err(task)` back
from `mutex.wait` and re-polls the same future in place. The task never
re-enters the pool's queue. Three tasks that do nothing but `yield_now()` in a
loop, on a two-worker pool, poll about 2.9 M times each for the first two and
zero times for the third.

The pipeline runs four tasks — video push, audio push, video pull, audio pull.
With two workers the two push tasks take both and hold them, so the pull tasks
are never polled, `releaseOutputBuffer` is never called, the codec never frees an
input buffer, and the push loops retry forever. Three workers pass because a pull
task gets a worker too and drains its stream, which lets the matching push task
finish and release a worker for the fourth task.

This is not confined to CI. `unienc_c` builds the same `ThreadPool` sized to the
machine, so a device with two usable cores on the CPU readback path meets the
same condition.

## What this does

Runs `dequeueInputBuffer` and `dequeueOutputBuffer` on the blocking pool through
`SpawnBlocking`, which the runtime already provides for exactly this. Awaiting a
blocking-pool result parks the task rather than occupying a worker, so the worker
is free for the rest of the pipeline, and the busy loop goes away with it: each
dequeue can now use a real timeout instead of polling with a zero one and
retrying.

`MediaCodecAudioEncoder` and `MediaCodecVideoEncoderOutput` gain the `Runtime`
handle this needs. `yield_now` is deleted rather than fixed, because there is no
correct self-waking yield on this executor.

The two dequeue helpers return an owned boxed future instead of being `async fn`,
so that no borrow of the runtime is held across the await; `Runtime` is `Send`
but not `Sync`.

## Verification

`scripts/android-device-test.sh` against an arm64 API 34 emulator with the
`google_apis` image, at `UNIENC_TEST_THREADS` of 1, 2 and 3 and with the default
pool. All four pass and produce the expected file:

```
movie: timescale 10000, duration 9.981 s, 2 track(s)
  audio: mp4a 48000 Hz 2 ch, 469 frames, start 0.000 s, 9.981 s, decoder config: true
  video: avc1 1280x720 (Baseline 4.1), 10 frames, start 0.000 s, 9.000 s
```

Before this change, two workers hung and three passed, repeatably.

The diagnosis came from `debuggerd -b` on the hung process: both workers sat in
`MediaCodec.dequeueInputBuffer`, one below `video::push_video_impl` and the other
below `audio::push_impl`, in twelve samples out of twelve, with no pull frame in
any of them.

## What this does not cover

The end-of-stream signal in `Drop` still waits synchronously, because `Drop`
cannot await. It is bounded and happens once per stream rather than once per
buffer, but it is the same shape, and both sites now say so in a comment.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
